### PR TITLE
Create errorHelper for handling errors

### DIFF
--- a/helpers/errorHelpers.js
+++ b/helpers/errorHelpers.js
@@ -1,0 +1,7 @@
+const createError = (status, message) => {
+    const error = new Error(message);
+    error.status = status;
+    return error;
+}
+
+export default createError;

--- a/middleware/credentials.js
+++ b/middleware/credentials.js
@@ -7,11 +7,11 @@ Then set the header in the response to true, as this is required by CORS.
 We obviously need to import this middleware in our server.js file.
 Right before the cors middleware.
 */
-const credencials = (req, res, next) => {
+const credentials = (req, res, next) => {
     const origin = req.headers.origin;
     if (allowedOrigins.includes(origin))
         res.setHeader('Access-Control-Allow-Origin', true);
     next();
 }
 
-export default credencials;
+export default credentials;

--- a/middleware/errorHandler.js
+++ b/middleware/errorHandler.js
@@ -7,6 +7,7 @@ const errorHandler = (err, req, res, next) => {
     const message = err.message || 'Something went wrong';
     //Log the error here
 
+
     res.status(status).json({ message });
 }
 


### PR DESCRIPTION
I already have a async Wrapper to help us deal with errors without using try / catch.
However, having res.status(xxx).json({}) didn't stop execution, so a better solution is to have a createError helper which allows for early return and using the expressJS next() we are able to direct ALL our exceptions to our errorHandler middleware, which then notifies the customer of the issue using our own status and message.

Also, this allows for better logging once I implement that.